### PR TITLE
Define UPOWER_ENABLE_DEPRECATED

### DIFF
--- a/cinnamon-session/csm-consolekit.c
+++ b/cinnamon-session/csm-consolekit.c
@@ -30,7 +30,7 @@
 
 #include <dbus/dbus-glib.h>
 #include <dbus/dbus-glib-lowlevel.h>
-
+#define UPOWER_ENABLE_DEPRECATED 1
 #include <upower.h>
 
 #include "csm-system.h"


### PR DESCRIPTION
ported to fix build error

https://git.gnome.org/browse/gnome-session/commit/gnome-session/gsm-consolekit.c?h=gnome-3-8&id=9646cc98b6a204f08c1ed06d75404610251e30e7

See http://cgit.freedesktop.org/upower/commit/?id=9843589d2d80e6dc2b3f51338e64bd1da1c53860
