### PR TITLE
Define UPOWER_ENABLE_DEPRECATED

### DIFF
--- a/cinnamon-session/csm-logout-dialog.c
+++ b/cinnamon-session/csm-logout-dialog.c
@@ -26,7 +26,7 @@
 
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-
+#define UPOWER_ENABLE_DEPRECATED 1
 #include <upower.h>
 
 #include "csm-logout-dialog.h"


### PR DESCRIPTION
ported to fix build error

https://git.gnome.org/browse/gnome-session/commit/gnome-session/gsm-logout-dialog.c?h=gnome-3-8&id=9646cc98b6a204f08c1ed06d75404610251e30e7
