### PR TITLE
Fix screensaver command on inhibit dialog

### DIFF
--- a/cinnamon-session/csm-inhibit-dialog.c
+++ b/cinnamon-session/csm-inhibit-dialog.c
@@ -97,7 +97,7 @@ lock_screen (CsmInhibitDialog *dialog)
 {
         GError *error;
         error = NULL;
-        g_spawn_command_line_async ("gnome-screensaver-command --lock", &error);
+        g_spawn_command_line_async ("cinnamon-screensaver-command --lock", &error);
         if (error != NULL) {
                 g_warning ("Couldn't lock screen: %s", error->message);
                 g_error_free (error);


### PR DESCRIPTION
gnome-screensaver-command is replaced by cinnamon-screensaver-command

Test case:
1. Open a new text file in gedit, type some character and don't save.
2. Try to log out (gnome-session-quit). The inhibit dialog shown.
3. Click on the 'Lock screen' button. Screensaver should be activated.
