### PR TITLE
Stop wallpapoz from autostarting as it breaks cinnamon background

### DIFF
--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -101,7 +101,8 @@ const gchar *blacklist[] = {
                             "gnome-fallback-mount-helper",
                             "gnome-screensaver",
                             "mate-screensaver",
-                            "mate-keyring-daemon"
+                            "mate-keyring-daemon",
+                            "wallpapoz-autostart"
                            };
 
 static void app_registered (CsmApp     *app, CsmManager *manager);


### PR DESCRIPTION
We really don't need to apps doing the bg

https://bugzilla.redhat.com/show_bug.cgi?id=1029554
