### PR TITLE
fix boolean type

### DIFF
--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -166,7 +166,7 @@ struct CsmManagerPrivate
         gboolean                dbus_disconnected : 1;
 
         ca_context             *ca;
-        gboolean               *logout_sound_is_playing;
+        gboolean               logout_sound_is_playing;
 
 };
 


### PR DESCRIPTION
AFAIK, there's no point to use a `gboolean*` here since everything below assign `gboolean`'s to it (which causes warnings as well.). PLZ correct me if I'm missing sth....

This shouldn't break any api/abi either since it is private.
