### PR TITLE
Bind gettext domain to GETTEXT_PACKAGE macro rather than 'cinnamon-session'

### DIFF
--- a/capplet/main.c
+++ b/capplet/main.c
@@ -79,9 +79,9 @@ main (int argc, char *argv[])
         GError    *error;
         GtkWidget *dialog;
 
-        bindtextdomain ("cinnamon-session", "/usr/share/cinnamon/locale");
-        bind_textdomain_codeset ("cinnamon-session", "UTF-8");
-        textdomain ("cinnamon-session");
+        bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
+        bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        textdomain (GETTEXT_PACKAGE);
 
         error = NULL;
         if (! gtk_init_with_args (&argc, &argv, " - Cinnamon Session Properties", options, "cinnamon-session", &error)) {


### PR DESCRIPTION
Currently, the gettext domain is 'cinnamon-session' but the GETTEXT_PACKAGE macro and the translation file both have the name 'cinnamon-session-3.0', thus the translation failed to take effect.
