### PR TITLE
Blacklist gnome-initial-setup

### DIFF
--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -107,7 +107,10 @@ const gchar *blacklist[] = {
                             "gnome-screensaver",
                             "mate-screensaver",
                             "mate-keyring-daemon",
-                            "indicator-"
+                            "indicator-",
+                            "gnome-initial-setup-copy-worker",
+                            "gnome-initial-setup-first-login",
+                            "gnome-welcome-tour"
                            };
 
 static void app_registered (CsmApp     *app, CsmManager *manager);


### PR DESCRIPTION
gnome-initial-setup is an official part of GNOME, and contains some autostart files. It's not intended to be used in Cinnamon, therefore we need to blacklist it. (Patch from Fedora.)