### PR TITLE
packaging: bump standards version to 3.9.5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Source: cinnamon-session
 Section: gnome
 Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
-Standards-Version: 3.9.3
+Standards-Version: 3.9.5
 Build-Depends: cdbs (>= 0.4.41),
                dh-autoreconf,
                debhelper (>= 8),

--- a/debian/control.in
+++ b/debian/control.in
@@ -2,7 +2,7 @@ Source: cinnamon-session
 Section: gnome
 Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
-Standards-Version: 3.9.3
+Standards-Version: 3.9.5
 Build-Depends: cdbs (>= 0.4.41),
                dh-autoreconf,
                debhelper (>= 8),


### PR DESCRIPTION
This will fix a Lintian warning:
`W: cinnamon-session source: ancient-standards-version 3.9.3 (current is 3.9.5)`