### PR TITLE
install .desktop file in cinnamon-session package

### DIFF
--- a/debian/cinnamon-session-common.install
+++ b/debian/cinnamon-session-common.install
@@ -1,4 +1,3 @@
-usr/share/applications
 usr/share/icons
 usr/share/locale
 debian/55cinnamon-session_gnomerc etc/X11/Xsession.d

--- a/debian/cinnamon-session.install
+++ b/debian/cinnamon-session.install
@@ -1,5 +1,6 @@
 usr/bin/cinnamon-session*
 usr/lib/cinnamon-session*
+usr/share/applications
 usr/share/cinnamon-session/*.glade
 usr/share/cinnamon-session/hardware-compatibility
 usr/share/man/man1

--- a/debian/control.in
+++ b/debian/control.in
@@ -38,6 +38,8 @@ Depends: ${shlibs:Depends},
          cinnamon-session-common,
          consolekit,
          upower (>= 0.9.0)
+Replaces: cinnamon-session-common (<< 2.4.3)
+Breaks: cinnamon-session-common (<< 2.4.3)
 Description: Cinnamon Session Manager - Minimal runtime
  The Cinnamon Session Manager is in charge of starting the core components
  of the Cinnamon desktop, and applications that should be launched at
@@ -52,6 +54,8 @@ Description: Cinnamon Session Manager - Minimal runtime
 Package: cinnamon-session-common
 Architecture: all
 Depends: ${misc:Depends}
+Replaces: cinnamon-session (<< 2.4.3)
+Breaks: cinnamon-session (<< 2.4.3)
 Description: Cinnamon Session Manager - common files
  The Cinnamon Session Manager is in charge of starting the core components
  of the Cinnamon desktop, and applications that should be launched at

--- a/debian/control.in
+++ b/debian/control.in
@@ -38,8 +38,8 @@ Depends: ${shlibs:Depends},
          cinnamon-session-common,
          consolekit,
          upower (>= 0.9.0)
-Replaces: cinnamon-session-common (<< 2.4.3)
-Breaks: cinnamon-session-common (<< 2.4.3)
+Replaces: cinnamon-session-common (<< 2.5.2)
+Breaks: cinnamon-session-common (<< 2.5.2)
 Description: Cinnamon Session Manager - Minimal runtime
  The Cinnamon Session Manager is in charge of starting the core components
  of the Cinnamon desktop, and applications that should be launched at
@@ -54,8 +54,8 @@ Description: Cinnamon Session Manager - Minimal runtime
 Package: cinnamon-session-common
 Architecture: all
 Depends: ${misc:Depends}
-Replaces: cinnamon-session (<< 2.4.3)
-Breaks: cinnamon-session (<< 2.4.3)
+Replaces: cinnamon-session (<< 2.5.2)
+Breaks: cinnamon-session (<< 2.5.2)
 Description: Cinnamon Session Manager - common files
  The Cinnamon Session Manager is in charge of starting the core components
  of the Cinnamon desktop, and applications that should be launched at


### PR DESCRIPTION
A desktop file for a command should be included in the same package as that command.
`W: cinnamon-session-common: desktop-command-not-in-package usr/share/applications/cinnamon-session-properties.desktop cinnamon-session-properties`