### PR TITLE
Removed overlay-scrollbar and add appmenu support

### DIFF
--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -369,23 +369,14 @@ main (int argc, char **argv)
 	                }
                         g_strfreev(tokens);
                 }
-                if (!g_str_match_string("unity-gtk-module", gtk_modules, FALSE)) {
-                        if (new_gtk_modules) {
-                                temp_gtk_modules = new_gtk_modules;
-                                new_gtk_modules = g_strconcat( "unity-gtk-module:", temp_gtk_modules, NULL );
-                                g_free (temp_gtk_modules);
-                        } else {
-                                new_gtk_modules = g_strconcat( "unity-gtk-module:", gtk_modules, NULL );
-                        }
+                if (g_str_match_string("unity-gtk-module", gtk_modules, FALSE)) {
+                	csm_util_setenv ("UBUNTU_MENUPROXY", "1");
                 }
                 if (new_gtk_modules) {
                         csm_util_setenv ("GTK_MODULES", new_gtk_modules);
                         g_free (new_gtk_modules);
                 }
-        } else {
-                csm_util_setenv ("GTK_MODULES", "unity-gtk-module");
         }
-        csm_util_setenv ("UBUNTU_MENUPROXY", "1");
 
         /* Some third-party programs rely on GNOME_DESKTOP_SESSION_ID to
          * detect if GNOME is running. We keep this for compatibility reasons.


### PR DESCRIPTION
Removed the overlay-scrollbar module if is present, because right now is not compatible with cinnamon Gtk widgets. This will be fixed : 
https://github.com/linuxmint/Cinnamon/issues/2771
https://github.com/linuxmint/Cinnamon/issues/3861
https://github.com/linuxmint/Cinnamon/issues/3763
https://github.com/linuxmint/Cinnamon/issues/3096
https://github.com/linuxmint/Cinnamon/issues/3168

Set unity-gtk-module explicitly if is not present, to add support for unity appmenu module and also set UBUNTU_MENUPROXY, to translate the Gtk2 menu style.