### PR TITLE
Fix translatable string

### DIFF
--- a/cinnamon-session/csm-logout-dialog.c
+++ b/cinnamon-session/csm-logout-dialog.c
@@ -369,7 +369,7 @@ csm_get_dialog (CsmDialogLogoutType type,
 
         current_dialog = logout_dialog;
 
-        gtk_window_set_title (GTK_WINDOW (logout_dialog), _("Session"));
+        gtk_window_set_title (GTK_WINDOW (logout_dialog), _(("Session")));
 
         logout_dialog->priv->type = type;
         


### PR DESCRIPTION
'Session' title in log out dialog isn't translatable without these two adittional brackets.
This package has also problem like cinnamon-settings-daemon package:
https://github.com/linuxmint/cinnamon-settings-daemon/issues/117