### PR TITLE
Fix broken gnome-keyring-3.20 autostart

### DIFF
--- a/cinnamon-session/README
+++ b/cinnamon-session/README
@@ -9,14 +9,20 @@ and session files to create a list of CsmApps to be started.
 (CsmAppAutostart represents an autostarted app, and CsmAppResumed
 represents an app resumed from the previous saved session.)
 
-Startup is divided into 6 phases (CsmSessionPhase):
+Startup is divided into 7 phases (CsmSessionPhase):
 
     * CSM_SESSION_PHASE_STARTUP covers cinnamon-session's internal
       startup, which also includes starting gconfd and dbus-daemon (if
       it's not already running). Gnome-session starts up those
       explicitly because it needs them for its own purposes.
 
-    * CSM_SESSION_PHASE_INITIALIZATION is the first phase of "normal"
+    * CSM_SESSION_PHASE_EARLY_INITIALIZATION is the first phase of
+      "normal" startup (ie, startup controlled by .desktop files
+      rather than hardcoding). It covers the possible installation of
+      files in $HOME by cinnamon-initial-setup and must be done before
+      other components such as gnome-keyring use those files.
+
+    * CSM_SESSION_PHASE_INITIALIZATION covers low-level stuff like
       startup (ie, startup controlled by .desktop files rather than
       hardcoding). It covers low-level stuff like
       gnome-settings-daemon and at-spi-registryd, that need to be

--- a/cinnamon-session/csm-autostart-app.c
+++ b/cinnamon-session/csm-autostart-app.c
@@ -617,7 +617,9 @@ load_desktop_file (CsmAutostartApp *app)
                                                  CSM_AUTOSTART_APP_PHASE_KEY,
                                                  NULL);
         if (phase_str != NULL) {
-                if (strcmp (phase_str, "Initialization") == 0) {
+                if (strcmp (phase_str, "PreDisplayServer") == 0) {
+                        phase = CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER;
+                } else if (strcmp (phase_str, "Initialization") == 0) {
                         phase = CSM_MANAGER_PHASE_INITIALIZATION;
                 } else if (strcmp (phase_str, "WindowManager") == 0) {
                         phase = CSM_MANAGER_PHASE_WINDOW_MANAGER;

--- a/cinnamon-session/csm-autostart-app.c
+++ b/cinnamon-session/csm-autostart-app.c
@@ -617,7 +617,9 @@ load_desktop_file (CsmAutostartApp *app)
                                                  CSM_AUTOSTART_APP_PHASE_KEY,
                                                  NULL);
         if (phase_str != NULL) {
-                if (strcmp (phase_str, "PreDisplayServer") == 0) {
+                if (strcmp (phase_str, "EarlyInitialization") == 0) {
+                        phase = CSM_MANAGER_PHASE_EARLY_INITIALIZATION;
+                } else if (strcmp (phase_str, "PreDisplayServer") == 0) {
                         phase = CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER;
                 } else if (strcmp (phase_str, "Initialization") == 0) {
                         phase = CSM_MANAGER_PHASE_INITIALIZATION;

--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -423,6 +423,9 @@ phase_num_to_name (guint phase)
         case CSM_MANAGER_PHASE_STARTUP:
                 name = "STARTUP";
                 break;
+        case CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER:
+                name = "PRE_DISPLAY_SERVER";
+                break;
         case CSM_MANAGER_PHASE_INITIALIZATION:
                 name = "INITIALIZATION";
                 break;
@@ -543,6 +546,7 @@ end_phase (CsmManager *manager)
 
         switch (manager->priv->phase) {
         case CSM_MANAGER_PHASE_STARTUP:
+        case CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER:
         case CSM_MANAGER_PHASE_INITIALIZATION:
         case CSM_MANAGER_PHASE_WINDOW_MANAGER:
         case CSM_MANAGER_PHASE_PANEL:
@@ -686,6 +690,7 @@ on_phase_timeout (CsmManager *manager)
 
         switch (manager->priv->phase) {
         case CSM_MANAGER_PHASE_STARTUP:
+        case CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER:
         case CSM_MANAGER_PHASE_INITIALIZATION:
         case CSM_MANAGER_PHASE_WINDOW_MANAGER:
         case CSM_MANAGER_PHASE_PANEL:
@@ -1606,6 +1611,7 @@ start_phase (CsmManager *manager)
 
         switch (manager->priv->phase) {
         case CSM_MANAGER_PHASE_STARTUP:
+        case CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER:
         case CSM_MANAGER_PHASE_INITIALIZATION:
         case CSM_MANAGER_PHASE_WINDOW_MANAGER:
         case CSM_MANAGER_PHASE_PANEL:

--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -423,6 +423,9 @@ phase_num_to_name (guint phase)
         case CSM_MANAGER_PHASE_STARTUP:
                 name = "STARTUP";
                 break;
+        case CSM_MANAGER_PHASE_EARLY_INITIALIZATION:
+                name = "EARLY_INITIALIZATION";
+                break;
         case CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER:
                 name = "PRE_DISPLAY_SERVER";
                 break;
@@ -546,6 +549,7 @@ end_phase (CsmManager *manager)
 
         switch (manager->priv->phase) {
         case CSM_MANAGER_PHASE_STARTUP:
+        case CSM_MANAGER_PHASE_EARLY_INITIALIZATION:
         case CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER:
         case CSM_MANAGER_PHASE_INITIALIZATION:
         case CSM_MANAGER_PHASE_WINDOW_MANAGER:
@@ -690,6 +694,7 @@ on_phase_timeout (CsmManager *manager)
 
         switch (manager->priv->phase) {
         case CSM_MANAGER_PHASE_STARTUP:
+        case CSM_MANAGER_PHASE_EARLY_INITIALIZATION:
         case CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER:
         case CSM_MANAGER_PHASE_INITIALIZATION:
         case CSM_MANAGER_PHASE_WINDOW_MANAGER:
@@ -1611,6 +1616,7 @@ start_phase (CsmManager *manager)
 
         switch (manager->priv->phase) {
         case CSM_MANAGER_PHASE_STARTUP:
+        case CSM_MANAGER_PHASE_EARLY_INITIALIZATION:
         case CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER:
         case CSM_MANAGER_PHASE_INITIALIZATION:
         case CSM_MANAGER_PHASE_WINDOW_MANAGER:
@@ -1669,7 +1675,7 @@ debug_app_summary (CsmManager *manager)
         guint phase;
 
         g_debug ("CsmManager: App startup summary");
-        for (phase = CSM_MANAGER_PHASE_INITIALIZATION; phase < CSM_MANAGER_PHASE_RUNNING; phase++) {
+        for (phase = CSM_MANAGER_PHASE_EARLY_INITIALIZATION; phase < CSM_MANAGER_PHASE_RUNNING; phase++) {
                 g_debug ("CsmManager: Phase %s", phase_num_to_name (phase));
                 csm_store_foreach (manager->priv->apps,
                                    (CsmStoreFunc)_debug_app_for_phase,
@@ -1685,7 +1691,7 @@ csm_manager_start (CsmManager *manager)
         g_return_if_fail (CSM_IS_MANAGER (manager));
 
         csm_xsmp_server_start (manager->priv->xsmp_server);
-        csm_manager_set_phase (manager, CSM_MANAGER_PHASE_INITIALIZATION);
+        csm_manager_set_phase (manager, CSM_MANAGER_PHASE_EARLY_INITIALIZATION);
         debug_app_summary (manager);
         start_phase (manager);
 }

--- a/cinnamon-session/csm-manager.h
+++ b/cinnamon-session/csm-manager.h
@@ -68,6 +68,8 @@ typedef struct
 typedef enum {
         /* csm's own startup/initialization phase */
         CSM_MANAGER_PHASE_STARTUP = 0,
+        /* gnome-initial-setup */
+        CSM_MANAGER_PHASE_EARLY_INITIALIZATION,
         /* gnome-keyring-daemon */
         CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER,
         /* xrandr setup, gnome-settings-daemon, etc */

--- a/cinnamon-session/csm-manager.h
+++ b/cinnamon-session/csm-manager.h
@@ -68,6 +68,8 @@ typedef struct
 typedef enum {
         /* csm's own startup/initialization phase */
         CSM_MANAGER_PHASE_STARTUP = 0,
+        /* gnome-keyring-daemon */
+        CSM_MANAGER_PHASE_PRE_DISPLAY_SERVER,
         /* xrandr setup, gnome-settings-daemon, etc */
         CSM_MANAGER_PHASE_INITIALIZATION,
         /* window/compositing managers */


### PR DESCRIPTION
gnome-keyring-3.20 no longer unlocks ssh key and more since this change

https://mail.gnome.org/archives/commits-list/2015-November/msg03206.html

