### PR TITLE
Add support for applying GTK style to QT apps when running QT 5.7+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ Makefile.in
 *.old
 *.bak
 
+## IDE files ##
+.idea
+CMakeLists.txt
+

--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -296,8 +296,6 @@ main (int argc, char **argv)
                 { "whale", 0, 0, G_OPTION_ARG_NONE, &please_fail, N_("Show the fail whale dialog for testing"), NULL },
                 { NULL, 0, 0, 0, NULL, NULL, NULL }
         };
-        gchar *qt_platform_theme_current = NULL;
-        gchar *qt_style_override_current = NULL;
         char *qt_platform_theme_new = NULL;
 
         /* Make sure that we have a session bus */
@@ -390,20 +388,15 @@ main (int argc, char **argv)
         /* Make QT5 apps follow the GTK style. Starting with QT 5.7, a different
          * env var has to be set than what worked in previous versions.
          */
-        qt_platform_theme_current = g_getenv ("QT_QPA_PLATFORMTHEME");
-        qt_style_override_current = g_getenv ("QT_STYLE_OVERRIDE");
         qt_platform_theme_new = HAVE_QT57 ? "qt5ct" : "qgnomeplatform";
 
-        if (NULL == qt_platform_theme_current) {
+        if (NULL == g_getenv ("QT_QPA_PLATFORMTHEME")) {
             csm_util_setenv ("QT_QPA_PLATFORMTHEME", qt_platform_theme_new);
         }
 
-        if (NULL == qt_style_override_current) {
+        if (NULL == g_getenv ("QT_STYLE_OVERRIDE")) {
             csm_util_setenv ("QT_STYLE_OVERRIDE", "gtk");
         }
-
-        g_free(qt_platform_theme_current);
-        g_free(qt_style_override_current);
 
 
         /* GTK Overlay scrollbars */

--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -404,7 +404,6 @@ main (int argc, char **argv)
 
         g_free(qt_platform_theme_current);
         g_free(qt_style_override_current);
-        g_free(qt_platform_theme_new);
 
 
         /* GTK Overlay scrollbars */

--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -394,8 +394,11 @@ main (int argc, char **argv)
             csm_util_setenv ("QT_QPA_PLATFORMTHEME", qt_platform_theme_new);
         }
 
-        if (NULL == g_getenv ("QT_STYLE_OVERRIDE")) {
+        if ( ! HAVE_QT57 && NULL == g_getenv ("QT_STYLE_OVERRIDE") ) {
             csm_util_setenv ("QT_STYLE_OVERRIDE", "gtk");
+
+        } else if (HAVE_QT57 && NULL != g_getenv ("QT_STYLE_OVERRIDE")) {
+            g_unsetenv ("QT_STYLE_OVERRIDE");
         }
 
 

--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -296,6 +296,9 @@ main (int argc, char **argv)
                 { "whale", 0, 0, G_OPTION_ARG_NONE, &please_fail, N_("Show the fail whale dialog for testing"), NULL },
                 { NULL, 0, 0, 0, NULL, NULL, NULL }
         };
+        gchar *qt_platform_theme_current = NULL;
+        gchar *qt_style_override_current = NULL;
+        char *qt_platform_theme_new = NULL;
 
         /* Make sure that we have a session bus */
         if (!require_dbus_session (argc, argv, &error)) {
@@ -383,8 +386,26 @@ main (int argc, char **argv)
          */
         csm_util_setenv ("GNOME_DESKTOP_SESSION_ID", "this-is-deprecated");
 
-        /* Make QT5 apps follow the GTK style */
-        csm_util_setenv ("QT_STYLE_OVERRIDE", "gtk");
+
+        /* Make QT5 apps follow the GTK style. Starting with QT 5.7, a different
+         * env var has to be set than what worked in previous versions.
+         */
+        qt_platform_theme_current = g_getenv ("QT_QPA_PLATFORMTHEME");
+        qt_style_override_current = g_getenv ("QT_STYLE_OVERRIDE");
+        qt_platform_theme_new = HAVE_QT57 ? "qt5ct" : "qgnomeplatform";
+
+        if (NULL == qt_platform_theme_current) {
+            csm_util_setenv ("QT_QPA_PLATFORMTHEME", qt_platform_theme_new);
+        }
+
+        if (NULL == qt_style_override_current) {
+            csm_util_setenv ("QT_STYLE_OVERRIDE", "gtk");
+        }
+
+        g_free(qt_platform_theme_current);
+        g_free(qt_style_override_current);
+        g_free(qt_platform_theme_new);
+
 
         /* GTK Overlay scrollbars */
         settings = g_settings_new ("org.cinnamon.desktop.interface");

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,8 @@ AC_ARG_ENABLE(qt57_theme_support,
 
 if test x$enable_qt57_theme_support = xyes; then
     AC_DEFINE([HAVE_QT57], [1], [Have QT 5.7+])
+else
+    AC_DEFINE([HAVE_QT57], [0], [Have QT 5.7+])
 fi
 
 dnl ====================================================================

--- a/configure.ac
+++ b/configure.ac
@@ -108,15 +108,15 @@ AC_SUBST(LOGIND_CFLAGS)
 AC_SUBST(LOGIND_LIBS)
 
 dnl ====================================================================
-dnl Check for qt 5.7+ to set correct env var for theme
+dnl Check for qt 5.7+ to set correct env var for theme/styling
 dnl ====================================================================
-PKG_CHECK_MODULES([QT57], [qt-5.0 >= 5.7],
-   [AC_DEFINE([HAVE_QT57], [1], [Have Qt 5.7+])],
-       [AC_DEFINE([HAVE_QT57], [0], [Have Qt 5.7+])]
-)
-AM_CONDITIONAL([HAVE_QT57], [test "$HAVE_QT57" -eq 1])
-if test $HAVE_QT57=1; then
-    AC_DEFINE(HAVE_QT57, 1, [Have QT 5.7+])
+AC_ARG_ENABLE(qt57_theme_support,
+              AS_HELP_STRING([--enable-qt57-theme-support], [Support GTK styles for QT apps with QT 5.7+]),
+              [enable_qt57_theme_support=yes],
+              [enable_qt57_theme_support=no])
+
+if test x$enable_qt57_theme_support = xyes; then
+    AC_DEFINE([HAVE_QT57], [1], [Have QT 5.7+])
 fi
 
 dnl ====================================================================
@@ -361,12 +361,13 @@ echo "
 
         GConf support:            ${enable_gconf}
         Logind support:           ${have_logind}
+        Qt 5.7+ theme support:    ${enable_qt57_theme_support}
         IPv6 support:             ${have_full_ipv6}
         Backtrace support:        ${have_backtrace}
         XRender support:          ${have_xrender}
         XSync support:            ${have_xsync}
         XTest support:            ${have_xtest}
-	Legacy UPower backend:    ${have_old_upower}
+        Legacy UPower backend:    ${have_old_upower}
         Build documentation:      ${enable_docbook_docs}
 
 "

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,18 @@ AC_SUBST(LOGIND_CFLAGS)
 AC_SUBST(LOGIND_LIBS)
 
 dnl ====================================================================
+dnl Check for qt 5.7+ to set correct env var for theme
+dnl ====================================================================
+PKG_CHECK_MODULES([QT57], [qt-5.0 >= 5.7],
+   [AC_DEFINE([HAVE_QT57], [1], [Have Qt 5.7+])],
+       [AC_DEFINE([HAVE_QT57], [0], [Have Qt 5.7+])]
+)
+AM_CONDITIONAL([HAVE_QT57], [test "$HAVE_QT57" -eq 1])
+if test $HAVE_QT57=1; then
+    AC_DEFINE(HAVE_QT57, 1, [Have QT 5.7+])
+fi
+
+dnl ====================================================================
 dnl X development libraries check
 dnl ====================================================================
 


### PR DESCRIPTION
Also maintain backwards compatibility for earlier versions of QT.

Ref links:
GNOME/gnome-session@ce4208a
manjaro/release-plan#73