### PR TITLE
theming for qt5, qt5.7 and qt5ct-v0.25

### DIFF
--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -296,6 +296,7 @@ main (int argc, char **argv)
                 { "whale", 0, 0, G_OPTION_ARG_NONE, &please_fail, N_("Show the fail whale dialog for testing"), NULL },
                 { NULL, 0, 0, 0, NULL, NULL, NULL }
         };
+        char *qt_platform_theme_new = NULL;
 
         /* Make sure that we have a session bus */
         if (!require_dbus_session (argc, argv, &error)) {
@@ -384,7 +385,22 @@ main (int argc, char **argv)
         csm_util_setenv ("GNOME_DESKTOP_SESSION_ID", "this-is-deprecated");
 
         /* Make QT5 apps follow the GTK style */
-        csm_util_setenv ("QT_STYLE_OVERRIDE", "gtk");
+        if (NULL == g_getenv ("QT_STYLE_OVERRIDE")) {
+            csm_util_setenv ("QT_STYLE_OVERRIDE", "gtk");
+        }
+
+        /* Make QT5 apps follow the GTK style. Starting with QT 5.7, a different
+         * env var has to be set than what worked in previous versions.
+         */
+        qt_platform_theme_new = HAVE_QT57 ? "qt5ct" : "qgnomeplatform";
+
+        if (NULL == g_getenv ("QT_QPA_PLATFORMTHEME")) {
+            csm_util_setenv ("QT_QPA_PLATFORMTHEME", qt_platform_theme_new);
+        }
+
+        if (strcmp(g_getenv ("QT_QPA_PLATFORMTHEME"), "qt5ct") == 0) {
+            g_unsetenv ("QT_STYLE_OVERRIDE");
+        }
 
         /* GTK Overlay scrollbars */
         settings = g_settings_new ("org.cinnamon.desktop.interface");

--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ dnl ====================================================================
 dnl Check for logind
 dnl ====================================================================
 
-PKG_CHECK_MODULES(LOGIND, [gio-unix-2.0 libsystemd-login], [have_logind=yes], [
+PKG_CHECK_MODULES(LOGIND, [gio-unix-2.0 libsystemd], [have_logind=yes], [
  PKG_CHECK_MODULES(LOGIND, [gio-unix-2.0 libsystemd], [have_logind=yes], [have_logind=no])
 ])
 
@@ -106,6 +106,20 @@ fi
 
 AC_SUBST(LOGIND_CFLAGS)
 AC_SUBST(LOGIND_LIBS)
+
+dnl ====================================================================
+dnl Check for qt 5.7+ to set correct env var for theme/styling
+dnl ====================================================================
+AC_ARG_ENABLE(qt57_theme_support,
+              AS_HELP_STRING([--enable-qt57-theme-support], [Support GTK styles for QT apps with QT 5.7+]),
+              [enable_qt57_theme_support=yes],
+              [enable_qt57_theme_support=no])
+
+if test x$enable_qt57_theme_support = xyes; then
+    AC_DEFINE([HAVE_QT57], [1], [Have QT 5.7+])
+else
+    AC_DEFINE([HAVE_QT57], [0], [Have QT 5.7+])
+fi
 
 dnl ====================================================================
 dnl X development libraries check
@@ -349,12 +363,13 @@ echo "
 
         GConf support:            ${enable_gconf}
         Logind support:           ${have_logind}
+        Qt 5.7+ theme support:    ${enable_qt57_theme_support}
         IPv6 support:             ${have_full_ipv6}
         Backtrace support:        ${have_backtrace}
         XRender support:          ${have_xrender}
         XSync support:            ${have_xsync}
         XTest support:            ${have_xtest}
-	Legacy UPower backend:    ${have_old_upower}
+        Legacy UPower backend:    ${have_old_upower}
         Build documentation:      ${enable_docbook_docs}
 
 "


### PR DESCRIPTION
Based on @lots0logs 's [PR](https://github.com/linuxmint/cinnamon-session/pull/75) and referring to my [comment](https://github.com/linuxmint/cinnamon-session/pull/75#issuecomment-244630571) there, this will export ``QT_STYLE_OVERRIDE=gtk`` for older QT5 versions.
From QT5.7 it will export ``QT_QPA_PLATFORMTHEME`` like in lots0log's PR, but in case ``QT_QPA_PLATFORMTHEME=qt5ct`` it will unset ``QT_STYLE_OVERRIDE`` and ensure that **qt5ct** will be able to run.