### PR TITLE
Migrate away from gnome-common deprecated vars and macros

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,22 +1,38 @@
-#!/bin/bash
+#!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="cinnamon-session"
-REQUIRED_AUTOMAKE_VERSION=1.10
+cd $srcdir
 
-(test -f $srcdir/configure.ac \
-  && test -d $srcdir/cinnamon-session) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level cinnamon-session directory"
+(test -f configure.ac) || {
+    echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
     exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from GNOME Subversion (or from"
-    echo "your distribution's package manager)."
-    exit 1
-}
-USE_GNOME2_MACROS=1 USE_COMMON_DOC_BUILD=yes . gnome-autogen.sh
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
+
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+    echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+    echo "*** If you wish to pass any to it, please specify them on the" >&2
+    echo "*** '$0' command line." >&2
+    echo "" >&2
+fi
+
+aclocal --install || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+    $srcdir/configure "$@" || exit 1
+
+    if [ "$1" = "--help" ]; then exit 0 else
+        echo "Now type 'make' to compile $PKG_NAME" || exit 1
+    fi
+else
+    echo "Skipping configure process."
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_CONFIG_SRCDIR([cinnamon-session])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
+m4_ifdef([AX_IS_RELEASE], [AX_IS_RELEASE([always])])
+
 AM_INIT_AUTOMAKE([1.11 no-dist-gzip dist-xz tar-ustar])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
@@ -20,8 +22,8 @@ PKG_PROG_PKG_CONFIG()
 LT_PREREQ([2.2.6])
 LT_INIT([dlopen disable-static])
 
-GNOME_MAINTAINER_MODE_DEFINES
-GNOME_COMPILE_WARNINGS([maximum])
+m4_ifdef([AX_COMPILER_FLAGS],
+         [AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS])])
 
 AC_ARG_ENABLE(deprecation_flags,
               [AS_HELP_STRING([--enable-deprecation-flags],
@@ -155,7 +157,7 @@ fi
 AC_CHECK_LIB(Xau, XauFileName, [X_LIBS="$X_LIBS -lXau"],
              [AC_MSG_ERROR([
 *** Can't find the Xauth library. It is needed to compile cinnamon-session.])],
-	     $X_LIBS)
+             $X_LIBS)
 
 AC_SUBST(X_LIBS)
 
@@ -208,21 +210,21 @@ AC_ARG_ENABLE(docbook-docs,
 AC_PATH_PROG(XMLTO, xmlto, no)
 AC_MSG_CHECKING([whether to build DocBook documentation])
 if test x$XMLTO = xno ; then
-	have_docbook=no
+    have_docbook=no
 else
-	have_docbook=yes
+    have_docbook=yes
 fi
 if test x$enable_docbook_docs = xauto ; then
-	if test x$have_docbook = xno ; then
-        	enable_docbook_docs=no
-	else
-		enable_docbook_docs=yes
-	fi
+    if test x$have_docbook = xno ; then
+        enable_docbook_docs=no
+    else
+        enable_docbook_docs=yes
+    fi
 fi
 if test x$enable_docbook_docs = xyes; then
-	if test x$have_docbook = xno; then
-		AC_MSG_ERROR([Building DocBook docs explicitly required, but DocBook not found])
-	fi
+    if test x$have_docbook = xno; then
+        AC_MSG_ERROR([Building DocBook docs explicitly required, but DocBook not found])
+    fi
 fi
 AM_CONDITIONAL(DOCBOOK_DOCS_ENABLED, test x$enable_docbook_docs = xyes)
 AC_MSG_RESULT($enable_docbook_docs)

--- a/debian/control
+++ b/debian/control
@@ -2,9 +2,9 @@ Source: cinnamon-session
 Section: x11
 Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
-Build-Depends: debhelper (>= 9),
+Build-Depends: autoconf-archive,
+               debhelper (>= 9),
                dh-autoreconf,
-               gnome-common,
                gnome-pkg-tools (>= 0.13),
                intltool (>= 0.40.6),
                libcanberra-dev,


### PR DESCRIPTION
gnome-common is deprecating some vars and macros, listed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829932

This change follows the gnome recommendations from:
https://wiki.gnome.org/Projects/GnomeCommon/Migration