### PR TITLE
main: fix heap overflow in dbus-launch wrapping

### DIFF
--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -253,7 +253,7 @@ require_dbus_session (int      argc,
                               TRUE);
 
         /* +2 for our new arguments, +1 for NULL */
-        new_argv = g_malloc (argc + 3 * sizeof (*argv));
+        new_argv = g_malloc ((argc + 3) * sizeof (*argv));
 
         new_argv[0] = "dbus-launch";
         new_argv[1] = "--exit-with-session";


### PR DESCRIPTION
Based on

https://git.gnome.org/browse/gnome-session/commit/?id=7ee3571c79ea202a8309f64f3cb235119178d080