### PR TITLE
Add support for "hybrid sleep"

### DIFF
--- a/cinnamon-session/csm-consolekit.c
+++ b/cinnamon-session/csm-consolekit.c
@@ -774,6 +774,12 @@ csm_consolekit_is_login_session (CsmSystem *system)
 }
 
 static gboolean
+csm_consolekit_can_hybrid_sleep (CsmSystem *system)
+{
+        return FALSE;
+}
+
+static gboolean
 csm_consolekit_can_suspend (CsmSystem *system)
 {
         CsmConsolekit *consolekit = CSM_CONSOLEKIT (system);
@@ -796,6 +802,11 @@ csm_consolekit_can_hibernate (CsmSystem *system)
         return FALSE;
 #endif
 
+}
+
+static void
+csm_consolekit_hybrid_sleep (CsmSystem *system)
+{
 }
 
 static void
@@ -849,10 +860,12 @@ csm_consolekit_system_init (CsmSystemInterface *iface)
         iface->can_switch_user = csm_consolekit_can_switch_user;
         iface->can_stop = csm_consolekit_can_stop;
         iface->can_restart = csm_consolekit_can_restart;
+        iface->can_hybrid_sleep = csm_consolekit_can_hybrid_sleep;
         iface->can_suspend = csm_consolekit_can_suspend;
         iface->can_hibernate = csm_consolekit_can_hibernate;
         iface->attempt_stop = csm_consolekit_attempt_stop;
         iface->attempt_restart = csm_consolekit_attempt_restart;
+        iface->hybrid_sleep = csm_consolekit_hybrid_sleep;
         iface->suspend = csm_consolekit_suspend;
         iface->hibernate = csm_consolekit_hibernate;
         iface->set_session_idle = csm_consolekit_set_session_idle;

--- a/cinnamon-session/csm-system.c
+++ b/cinnamon-session/csm-system.c
@@ -83,6 +83,12 @@ csm_system_can_restart (CsmSystem *system)
 }
 
 gboolean
+csm_system_can_hybrid_sleep (CsmSystem *system)
+{
+        return CSM_SYSTEM_GET_IFACE (system)->can_hybrid_sleep (system);
+}
+
+gboolean
 csm_system_can_suspend (CsmSystem *system)
 {
         return CSM_SYSTEM_GET_IFACE (system)->can_suspend (system);
@@ -104,6 +110,12 @@ void
 csm_system_attempt_restart (CsmSystem *system)
 {
         CSM_SYSTEM_GET_IFACE (system)->attempt_restart (system);
+}
+
+void
+csm_system_hybrid_sleep (CsmSystem *system)
+{
+        CSM_SYSTEM_GET_IFACE (system)->hybrid_sleep (system);
 }
 
 void

--- a/cinnamon-session/csm-system.h
+++ b/cinnamon-session/csm-system.h
@@ -52,10 +52,12 @@ struct _CsmSystemInterface
         gboolean (* can_switch_user)  (CsmSystem *system);
         gboolean (* can_stop)         (CsmSystem *system);
         gboolean (* can_restart)      (CsmSystem *system);
+        gboolean (* can_hybrid_sleep) (CsmSystem *system);
         gboolean (* can_suspend)      (CsmSystem *system);
         gboolean (* can_hibernate)    (CsmSystem *system);
         void     (* attempt_stop)     (CsmSystem *system);
         void     (* attempt_restart)  (CsmSystem *system);
+        void     (* hybrid_sleep)     (CsmSystem *system);
         void     (* suspend)          (CsmSystem *system);
         void     (* hibernate)        (CsmSystem *system);
         void     (* set_session_idle) (CsmSystem *system,
@@ -85,6 +87,8 @@ gboolean   csm_system_can_stop         (CsmSystem *system);
 
 gboolean   csm_system_can_restart      (CsmSystem *system);
 
+gboolean   csm_system_can_hybrid_sleep (CsmSystem *system);
+
 gboolean   csm_system_can_suspend      (CsmSystem *system);
 
 gboolean   csm_system_can_hibernate    (CsmSystem *system);
@@ -92,6 +96,8 @@ gboolean   csm_system_can_hibernate    (CsmSystem *system);
 void       csm_system_attempt_stop     (CsmSystem *system);
 
 void       csm_system_attempt_restart  (CsmSystem *system);
+
+void       csm_system_hybrid_sleep     (CsmSystem *system);
 
 void       csm_system_suspend          (CsmSystem *system);
 

--- a/data/org.cinnamon.SessionManager.gschema.xml.in
+++ b/data/org.cinnamon.SessionManager.gschema.xml.in
@@ -38,5 +38,10 @@
       <summary>The time delay before quitting the system automatically</summary>
       <description>The time delay before the shutdown/logout dialogue quits the system automatically</description>
     </key>
+    <key name="prefer-hybrid-sleep" type="b">
+      <default>false</default>
+      <summary>If your hardware and login service supports 'Hybrid Sleep' then use it instead of normal Suspend</summary>
+      <description>Whether or not to attempt to use hybrid sleep mode for suspend.  If it is unsupported, normal sleep will be used instead</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
for now, to enable it, it's anundocumented dconf setting, and replaces normal suspend if active.

As for future exposure to a user, I have a few opinions.

- This mode seems to me to be superior to either conventional suspend
  or hibernate.
- I think we definitely don't want yet another button on our logout
  dialog.  If this is available/enabled, this is all we should show.
- In our power prefs, where some enabling switch might be, activating
  should set all other suspend/hibernate settings to use this instead.
- This preference is only intended as a temporary thing (I didn't want
  this implementation to span multiple packages for now) - probably it
  should live in power preferencess?