### PR TITLE
Restart dbus user-session if last graphical session

### DIFF
--- a/cinnamon-session/csm-consolekit.c
+++ b/cinnamon-session/csm-consolekit.c
@@ -854,6 +854,12 @@ csm_consolekit_remove_inhibitor (CsmSystem   *system,
 {
 }
 
+static gboolean
+csm_consolekit_is_last_session_for_user (CsmSystem *system)
+{
+        return FALSE;
+}
+
 static void
 csm_consolekit_system_init (CsmSystemInterface *iface)
 {
@@ -872,6 +878,7 @@ csm_consolekit_system_init (CsmSystemInterface *iface)
         iface->is_login_session = csm_consolekit_is_login_session;
         iface->add_inhibitor = csm_consolekit_add_inhibitor;
         iface->remove_inhibitor = csm_consolekit_remove_inhibitor;
+        iface->is_last_session_for_user = csm_consolekit_is_last_session_for_user;
 }
 
 CsmConsolekit *

--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -939,6 +939,38 @@ _client_stop (const char *id,
 }
 
 static void
+maybe_restart_user_bus (CsmManager *manager)
+{
+        CsmSystem *system;
+        g_autoptr(GVariant) reply = NULL;
+        g_autoptr(GError) error = NULL;
+
+        if (manager->priv->dbus_disconnected)
+                return;
+
+        system = csm_get_system ();
+
+        if (!csm_system_is_last_session_for_user (system))
+                return;
+
+        reply = g_dbus_connection_call_sync (manager->priv->connection,
+                                             "org.freedesktop.systemd1",
+                                             "/org/freedesktop/systemd1",
+                                             "org.freedesktop.systemd1.Manager",
+                                             "TryRestartUnit",
+                                             g_variant_new ("(ss)", "dbus.service", "replace"),
+                                             NULL,
+                                             G_DBUS_CALL_FLAGS_NONE,
+                                             -1,
+                                             NULL,
+                                             &error);
+
+        if (error != NULL) {
+                g_debug ("CsmManager: reloading user bus failed: %s", error->message);
+        }
+}
+
+static void
 do_phase_exit (CsmManager *manager)
 {
         if (csm_store_size (manager->priv->clients) > 0) {
@@ -946,6 +978,7 @@ do_phase_exit (CsmManager *manager)
                                    (CsmStoreFunc)_client_stop,
                                    NULL);
         }
+        maybe_restart_user_bus (manager);
         end_phase (manager);
 }
 

--- a/cinnamon-session/csm-system.c
+++ b/cinnamon-session/csm-system.c
@@ -158,6 +158,12 @@ csm_system_is_login_session (CsmSystem *system)
         return CSM_SYSTEM_GET_IFACE (system)->is_login_session (system);
 }
 
+gboolean
+csm_system_is_last_session_for_user (CsmSystem *system)
+{
+        return CSM_SYSTEM_GET_IFACE (system)->is_last_session_for_user (system);
+}
+
 CsmSystem *
 csm_get_system (void)
 {

--- a/cinnamon-session/csm-system.h
+++ b/cinnamon-session/csm-system.h
@@ -68,6 +68,7 @@ struct _CsmSystemInterface
                                        CsmInhibitorFlag  flags);
         void     (* remove_inhibitor) (CsmSystem        *system,
                                        const gchar      *id);
+        gboolean (* is_last_session_for_user) (CsmSystem *system);
 };
 
 enum _CsmSystemError {
@@ -107,6 +108,8 @@ void       csm_system_set_session_idle (CsmSystem *system,
                                         gboolean   is_idle);
 
 gboolean   csm_system_is_login_session (CsmSystem *system);
+
+gboolean   csm_system_is_last_session_for_user (CsmSystem *system);
 
 void       csm_system_add_inhibitor    (CsmSystem        *system,
                                         const gchar      *id,

--- a/cinnamon-session/csm-systemd.c
+++ b/cinnamon-session/csm-systemd.c
@@ -648,6 +648,66 @@ csm_systemd_remove_inhibitor (CsmSystem   *system,
         }
 }
 
+static gboolean
+csm_systemd_is_last_session_for_user (CsmSystem *system)
+{
+        char **sessions = NULL;
+        char *session = NULL;
+        gboolean is_last_session;
+        int ret, i;
+
+        ret = sd_pid_get_session (getpid (), &session);
+
+        if (ret != 0) {
+                return FALSE;
+        }
+
+        ret = sd_uid_get_sessions (getuid (), FALSE, &sessions);
+
+        if (ret <= 0) {
+                return FALSE;
+        }
+
+        is_last_session = TRUE;
+        for (i = 0; sessions[i]; i++) {
+                char *state = NULL;
+                char *type = NULL;
+
+                if (g_strcmp0 (sessions[i], session) == 0)
+                        continue;
+
+                ret = sd_session_get_state (sessions[i], &state);
+
+                if (ret != 0)
+                        continue;
+
+                if (g_strcmp0 (state, "closing") == 0) {
+                        free (state);
+                        continue;
+                }
+                free (state);
+
+                ret = sd_session_get_type (sessions[i], &type);
+
+                if (ret != 0)
+                        continue;
+
+                if (g_strcmp0 (type, "x11") != 0 &&
+                    g_strcmp0 (type, "wayland") != 0) {
+                        free (type);
+                        continue;
+                }
+
+                is_last_session = FALSE;
+        }
+
+        for (i = 0; sessions[i]; i++)
+                free (sessions[i]);
+        free (sessions);
+
+        return is_last_session;
+}
+
 static void
 csm_systemd_system_init (CsmSystemInterface *iface)
 {
@@ -666,6 +726,7 @@ csm_systemd_system_init (CsmSystemInterface *iface)
         iface->is_login_session = csm_systemd_is_login_session;
         iface->add_inhibitor = csm_systemd_add_inhibitor;
         iface->remove_inhibitor = csm_systemd_remove_inhibitor;
+        iface->is_last_session_for_user = csm_systemd_is_last_session_for_user;
 }
 
 CsmSystemd *


### PR DESCRIPTION
There are desktop services (such as goa-daemon, e-d-s, etc) that don't open the display, but rely on dbus-daemon to scope the session. These days dbus-daemon is a user bus, not a session, bus which leaves these services alive after log out.

This commit checks to see if we're the last desktop session for the user at log out time, and if so, restarts the dbus daemon. This will lead to existing clients getting booted and die, but allow user bus clients that want to outlive a session to stick around if they so desire.

Longer term, clients should stop relying on the session bus to define their lifetime.

https://bugzilla.gnome.org/show_bug.cgi?id=764029