### PR TITLE
cinnamon-session should not try to handle QT_STYLE_OVERRIDE and QT_QPA_PLATFORMTHEME

### DIFF
--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -340,24 +340,6 @@ main (int argc, char **argv)
          */
         csm_util_setenv ("GNOME_DESKTOP_SESSION_ID", "this-is-deprecated");
 
-
-        /* Make QT5 apps follow the GTK style. Starting with QT 5.7, a different
-         * env var has to be set than what worked in previous versions.
-         */
-        qt_platform_theme_new = HAVE_QT57 ? "qt5ct" : "qgnomeplatform";
-
-        if (NULL == g_getenv ("QT_QPA_PLATFORMTHEME")) {
-            csm_util_setenv ("QT_QPA_PLATFORMTHEME", qt_platform_theme_new);
-        }
-
-        if ( ! HAVE_QT57 && NULL == g_getenv ("QT_STYLE_OVERRIDE") ) {
-            csm_util_setenv ("QT_STYLE_OVERRIDE", "gtk");
-
-        } else if (HAVE_QT57 && NULL != g_getenv ("QT_STYLE_OVERRIDE")) {
-            g_unsetenv ("QT_STYLE_OVERRIDE");
-        }
-
-
         /* GTK Overlay scrollbars */
         settings = g_settings_new ("org.cinnamon.desktop.interface");
 


### PR DESCRIPTION
In commit 7c34ec9028c5f7b01e5393aeff78cc7e9a0cc8b5 cinnamon-session was modified to disrespect the user settings whenever a distro compiles with --enable-qt57-theme-support

This was presumably done in order to avoid issues where QT_QPA_PLATFORMTHEME was unspecified and we set it to qt5ct, but QT_STYLE_OVERRIDE was set -- which qt5ct considers an error. However, this means that users who specified both would have their style override deleted, even though we respected their platformtheme rather than setting it ourselves to qt5ct.

Also consider not setting this at all in any way, shape or form, as gnome itself has also removed this code entirely as a result of https://bugzilla.gnome.org/show_bug.cgi?id=762681