### PR TITLE
configure: Add option to disable support for DBus user sessions

### DIFF
--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -978,7 +978,11 @@ do_phase_exit (CsmManager *manager)
                                    (CsmStoreFunc)_client_stop,
                                    NULL);
         }
-        maybe_restart_user_bus (manager);
+
+        if (WITH_DBUS_USER_SESSION) {
+                maybe_restart_user_bus (manager);
+        }
+
         end_phase (manager);
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,19 @@ AC_SUBST(LOGIND_CFLAGS)
 AC_SUBST(LOGIND_LIBS)
 
 dnl ====================================================================
+dnl Option to disable DBus user session support.
+dnl ====================================================================
+AC_ARG_ENABLE([dbus_user_session],
+              AS_HELP_STRING([--disable-dbus-user-session], [Disable support for DBus user sessions]),
+              [], [enable_dbus_user_session=yes])
+
+if test x$enable_dbus_user_session = xyes; then
+    AC_DEFINE(WITH_DBUS_USER_SESSION, 1, [Define to 1 if support for DBus user session is enabled])
+else
+    AC_DEFINE(WITH_DBUS_USER_SESSION, 0, [Define to 0 if support for DBus user session is disabled])
+fi
+
+dnl ====================================================================
 dnl Check for qt 5.7+ to set correct env var for theme/styling
 dnl ====================================================================
 AC_ARG_ENABLE(qt57_theme_support,
@@ -371,6 +384,7 @@ echo "
 
         GConf support:            ${enable_gconf}
         Logind support:           ${have_logind}
+        DBus user session sup.:   ${enable_dbus_user_session}
         Qt 5.7+ theme support:    ${enable_qt57_theme_support}
         IPv6 support:             ${have_full_ipv6}
         Backtrace support:        ${have_backtrace}


### PR DESCRIPTION
This adds the option `--disable-dbus-user-session` to configure.

Optionally disabling DBus user sessions is needed on older distributions like RHEL 7 / CentOS 7, which do not support DBus user sessions through systemd.