### PR TITLE
csm-manager: Detect DBus user-session at runtime

### DIFF
--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -944,6 +944,10 @@ maybe_restart_user_bus (CsmManager *manager)
         CsmSystem *system;
         g_autoptr(GVariant) reply = NULL;
         g_autoptr(GError) error = NULL;
+        const char *user_unit = "/usr/lib/systemd/user/sockets.target.wants/dbus.socket";
+
+        if (!g_file_test (user_unit, G_FILE_TEST_EXISTS))
+                return;
 
         if (manager->priv->dbus_disconnected)
                 return;
@@ -978,11 +982,7 @@ do_phase_exit (CsmManager *manager)
                                    (CsmStoreFunc)_client_stop,
                                    NULL);
         }
-
-        if (WITH_DBUS_USER_SESSION) {
-                maybe_restart_user_bus (manager);
-        }
-
+        maybe_restart_user_bus (manager);
         end_phase (manager);
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -110,19 +110,6 @@ AC_SUBST(LOGIND_CFLAGS)
 AC_SUBST(LOGIND_LIBS)
 
 dnl ====================================================================
-dnl Option to disable DBus user session support.
-dnl ====================================================================
-AC_ARG_ENABLE([dbus_user_session],
-              AS_HELP_STRING([--disable-dbus-user-session], [Disable support for DBus user sessions]),
-              [], [enable_dbus_user_session=yes])
-
-if test x$enable_dbus_user_session = xyes; then
-    AC_DEFINE(WITH_DBUS_USER_SESSION, 1, [Define to 1 if support for DBus user session is enabled])
-else
-    AC_DEFINE(WITH_DBUS_USER_SESSION, 0, [Define to 0 if support for DBus user session is disabled])
-fi
-
-dnl ====================================================================
 dnl Check for qt 5.7+ to set correct env var for theme/styling
 dnl ====================================================================
 AC_ARG_ENABLE(qt57_theme_support,
@@ -384,7 +371,6 @@ echo "
 
         GConf support:            ${enable_gconf}
         Logind support:           ${have_logind}
-        DBus user session sup.:   ${enable_dbus_user_session}
         Qt 5.7+ theme support:    ${enable_qt57_theme_support}
         IPv6 support:             ${have_full_ipv6}
         Backtrace support:        ${have_backtrace}


### PR DESCRIPTION
This removes the configure option `--disable-dbus-user-session` and adds a runtime check instead.

DBus user sessions do not exist on older distributions like RHEL 7 / CentOS 7 and thus killing the DBus session there would cause a segfault when shutting down or loggin out of Cinnamon.