### PR TITLE
main: remove leftover qt theme support variable

### DIFF
--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -249,7 +249,6 @@ main (int argc, char **argv)
                 { "whale", 0, 0, G_OPTION_ARG_NONE, &please_fail, N_("Show the fail whale dialog for testing"), NULL },
                 { NULL, 0, 0, 0, NULL, NULL, NULL }
         };
-        char *qt_platform_theme_new = NULL;
 
         /* Make sure that we have a session bus */
         if (!require_dbus_session (argc, argv, &error)) {


### PR DESCRIPTION
unused since b02bfa5f0a39208fb457caff0c18f071921d6aef