### PR TITLE
Fix generation of LOCALE_DIR

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -149,7 +149,7 @@ conf.set_quoted('GTKBUILDER_DIR',     pkgdatadir)
 conf.set_quoted('DATA_DIR',           pkgdatadir)
 conf.set_quoted('PKGDATADIR',         pkgdatadir)
 conf.set_quoted('LIBEXECDIR',         get_option('libexecdir'))
-conf.set_quoted('LOCALE_DIR',         get_option('localedir'))
+conf.set_quoted('LOCALE_DIR',         join_paths(get_option('prefix'), get_option('localedir')))
 
 conf.set_quoted('PACKAGE', meson.project_name())
 conf.set_quoted('VERSION', meson.project_version())


### PR DESCRIPTION
This fixes a mistake, where LOCALE_DIR was used as "share/locale" in the code, where it should be "usr/share/locale"