### PR TITLE
build: fix PKGDATADIR define / use only one define

### DIFF
--- a/cinnamon-session/csm-inhibit-dialog.c
+++ b/cinnamon-session/csm-inhibit-dialog.c
@@ -1075,7 +1075,7 @@ csm_inhibit_dialog_init (CsmInhibitDialog *dialog)
 
         error = NULL;
         if (!gtk_builder_add_from_file (dialog->priv->xml,
-                                        GTKBUILDER_DIR "/" GTKBUILDER_FILE,
+                                        PKGDATADIR "/" GTKBUILDER_FILE,
                                         &error)) {
                 if (error) {
                         g_warning ("Could not load inhibitor UI file: %s",

--- a/meson.build
+++ b/meson.build
@@ -143,11 +143,7 @@ conf.set('ENABLE_IPV6', have_ipv6)
 
 rootInclude = include_directories('.')
 
-pkgdatadir = join_paths(get_option('datadir'), meson.project_name())
-
-conf.set_quoted('GTKBUILDER_DIR',     pkgdatadir)
-conf.set_quoted('DATA_DIR',           pkgdatadir)
-conf.set_quoted('PKGDATADIR',         pkgdatadir)
+conf.set_quoted('PKGDATADIR',         join_paths(get_option('prefix'), get_option('datadir'), meson.project_name()))
 conf.set_quoted('LIBEXECDIR',         get_option('libexecdir'))
 conf.set_quoted('LOCALE_DIR',         join_paths(get_option('prefix'), get_option('localedir')))
 


### PR DESCRIPTION
we need to prepend the prefix to get a full path, and there's
no reason to have 3 names for the same thing.

fixes (among others):
cinnamon-session[691]: WARNING: t+26.82904s: Could not load inhibitor UI file: Failed to open file “share/cinnamon-session/csm-inhibit-dialog.glade”: No such file or directory 