### PR TITLE
Implement suspend/hibernate via consolekit

### DIFF
--- a/cinnamon-session/csm-consolekit.c
+++ b/cinnamon-session/csm-consolekit.c
@@ -31,11 +31,6 @@
 #include <dbus/dbus-glib.h>
 #include <dbus/dbus-glib-lowlevel.h>
 
-#ifdef HAVE_OLD_UPOWER
-#define UPOWER_ENABLE_DEPRECATED 1
-#include <upower.h>
-#endif
-
 #include "csm-system.h"
 #include "csm-consolekit.h"
 
@@ -58,9 +53,6 @@ struct _CsmConsolekitPrivate
         DBusGConnection *dbus_connection;
         DBusGProxy      *bus_proxy;
         DBusGProxy      *ck_proxy;
-#ifdef HAVE_OLD_UPOWER
-        UpClient        *up_client;
-#endif
 };
 
 static void     csm_consolekit_finalize     (GObject            *object);
@@ -185,11 +177,6 @@ csm_consolekit_ensure_ck_connection (CsmConsolekit  *manager,
                 }
         }
 
-#ifdef HAVE_OLD_UPOWER
-        g_clear_object (&manager->priv->up_client);
-        manager->priv->up_client = up_client_new ();
-#endif
-
         is_connected = TRUE;
 
  out:
@@ -253,9 +240,6 @@ csm_consolekit_free_dbus (CsmConsolekit *manager)
 {
         g_clear_object (&manager->priv->bus_proxy);
         g_clear_object (&manager->priv->ck_proxy);
-#ifdef HAVE_OLD_UPOWER
-        g_clear_object (&manager->priv->up_client);
-#endif
 
         if (manager->priv->dbus_connection != NULL) {
                 DBusConnection *connection;
@@ -780,28 +764,55 @@ csm_consolekit_can_hybrid_sleep (CsmSystem *system)
 }
 
 static gboolean
+csm_consolekit_can_sleep (CsmSystem *system, const gchar *method)
+{
+        CsmConsolekit *manager = CSM_CONSOLEKIT (system);
+        gboolean res;
+        gchar *can_string;
+        GError *error;
+
+        error = NULL;
+
+        if (!csm_consolekit_ensure_ck_connection (manager, &error)) {
+                g_warning ("Could not connect to ConsoleKit: %s",
+                           error->message);
+                g_error_free (error);
+                return FALSE;
+        }
+
+        res = dbus_g_proxy_call_with_timeout (manager->priv->ck_proxy,
+                                              method,
+                                              INT_MAX,
+                                              &error,
+                                              G_TYPE_INVALID,
+                                              G_TYPE_STRING, &can_string,
+                                              G_TYPE_INVALID);
+
+        if (!res) {
+                g_warning ("Could not query %s from ConsoleKit: %s",
+                           method, error->message);
+                g_error_free (error);
+                return FALSE;
+        }
+
+        /* If yes or challenge then we can sleep, it just might take a password */
+        if (g_strcmp0 (can_string, "yes") == 0 || g_strcmp0 (can_string, "challenge") == 0) {
+              return TRUE;
+        } else {
+              return FALSE;
+        } 
+}
+
+static gboolean
 csm_consolekit_can_suspend (CsmSystem *system)
 {
-        CsmConsolekit *consolekit = CSM_CONSOLEKIT (system);
-
-#ifdef HAVE_OLD_UPOWER
-        return up_client_get_can_suspend (consolekit->priv->up_client);
-#else
-        return FALSE;
-#endif
+        return csm_consolekit_can_sleep(system, "CanSuspend");
 }
 
 static gboolean
 csm_consolekit_can_hibernate (CsmSystem *system)
 {
-        CsmConsolekit *consolekit = CSM_CONSOLEKIT (system);
-
-#ifdef HAVE_OLD_UPOWER
-        return up_client_get_can_hibernate (consolekit->priv->up_client);
-#else
-        return FALSE;
-#endif
-
+        return csm_consolekit_can_sleep(system, "CanHibernate");
 }
 
 static void
@@ -810,35 +821,48 @@ csm_consolekit_hybrid_sleep (CsmSystem *system)
 }
 
 static void
-csm_consolekit_suspend (CsmSystem *system)
+csm_consolekit_attempt_sleep (CsmSystem *system, const gchar *method)
 {
-#ifdef HAVE_OLD_UPOWER
-        CsmConsolekit *consolekit = CSM_CONSOLEKIT (system);
-        GError *error = NULL;
-        gboolean ret;
+        CsmConsolekit *manager = CSM_CONSOLEKIT (system);
+        gboolean res;
+        GError *error;
 
-        ret = up_client_suspend_sync (consolekit->priv->up_client, NULL, &error);
-        if (!ret) {
-                g_warning ("Unexpected suspend failure: %s", error->message);
+        error = NULL;
+
+        g_warning ("Attempting to %s using consolekit...", method);
+
+        if (!csm_consolekit_ensure_ck_connection (manager, &error)) {
+                g_warning ("Could not connect to ConsoleKit: %s",
+                           error->message);
+                g_signal_emit_by_name (G_OBJECT (manager), "request-failed", NULL);
+                g_error_free (error);
+                return ;
+        }
+
+        res = dbus_g_proxy_call_with_timeout (manager->priv->ck_proxy,
+                                              method,
+                                              INT_MAX,
+                                              &error,
+                                              G_TYPE_BOOLEAN, TRUE,
+                                              G_TYPE_INVALID);
+
+        if (!res) {
+                g_warning ("Unable to %s via consolekit: %s", method, error->message);
+                g_signal_emit_by_name (G_OBJECT (manager), "request-failed", NULL);
                 g_error_free (error);
         }
-#endif
+}
+
+static void
+csm_consolekit_suspend (CsmSystem *system)
+{
+        csm_consolekit_attempt_sleep (system, "Suspend");
 }
 
 static void
 csm_consolekit_hibernate (CsmSystem *system)
 {
-#ifdef HAVE_OLD_UPOWER
-        CsmConsolekit *consolekit = CSM_CONSOLEKIT (system);
-        GError *error = NULL;
-        gboolean ret;
-
-        ret = up_client_hibernate_sync (consolekit->priv->up_client, NULL, &error);
-        if (!ret) {
-                g_warning ("Unexpected hibernate failure: %s", error->message);
-                g_error_free (error);
-        }
-#endif
+        csm_consolekit_attempt_sleep (system, "Hibernate");
 }
 
 static void

--- a/cinnamon-session/csm-consolekit.c
+++ b/cinnamon-session/csm-consolekit.c
@@ -758,12 +758,6 @@ csm_consolekit_is_login_session (CsmSystem *system)
 }
 
 static gboolean
-csm_consolekit_can_hybrid_sleep (CsmSystem *system)
-{
-        return FALSE;
-}
-
-static gboolean
 csm_consolekit_can_sleep (CsmSystem *system, const gchar *method)
 {
         CsmConsolekit *manager = CSM_CONSOLEKIT (system);
@@ -815,9 +809,10 @@ csm_consolekit_can_hibernate (CsmSystem *system)
         return csm_consolekit_can_sleep(system, "CanHibernate");
 }
 
-static void
-csm_consolekit_hybrid_sleep (CsmSystem *system)
+static gboolean
+csm_consolekit_can_hybrid_sleep (CsmSystem *system)
 {
+        return csm_consolekit_can_sleep(system, "CanHybridSleep");
 }
 
 static void
@@ -863,6 +858,12 @@ static void
 csm_consolekit_hibernate (CsmSystem *system)
 {
         csm_consolekit_attempt_sleep (system, "Hibernate");
+}
+
+static void
+csm_consolekit_hybrid_sleep (CsmSystem *system)
+{
+        csm_consolekit_attempt_sleep (system, "HybridSleep");
 }
 
 static void

--- a/cinnamon-session/csm-logout-dialog.c
+++ b/cinnamon-session/csm-logout-dialog.c
@@ -26,10 +26,6 @@
 
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-#ifdef HAVE_OLD_UPOWER
-#define UPOWER_ENABLE_DEPRECATED 1
-#include <upower.h>
-#endif
 
 #include <libxapp/xapp-gtk-window.h>
 
@@ -52,9 +48,6 @@ struct _CsmLogoutDialogPrivate
 {
         CsmDialogLogoutType  type;
 
-#ifdef HAVE_OLD_UPOWER
-        UpClient            *up_client;
-#endif
         CsmSystem           *system;
         GtkWidget           *progressbar;
 
@@ -148,10 +141,6 @@ csm_logout_dialog_init (CsmLogoutDialog *logout_dialog)
         gtk_window_set_keep_above (GTK_WINDOW (logout_dialog), TRUE);
         gtk_window_stick (GTK_WINDOW (logout_dialog));
 
-#ifdef HAVE_OLD_UPOWER
-        logout_dialog->priv->up_client = up_client_new ();
-#endif
-
         logout_dialog->priv->system = csm_get_system ();
 
         g_signal_connect (logout_dialog,
@@ -173,13 +162,6 @@ csm_logout_dialog_destroy (CsmLogoutDialog *logout_dialog,
                 g_source_remove (logout_dialog->priv->timeout_id);
                 logout_dialog->priv->timeout_id = 0;
         }
-
-#ifdef HAVE_OLD_UPOWER 
-        if (logout_dialog->priv->up_client) {
-                g_object_unref (logout_dialog->priv->up_client);
-                logout_dialog->priv->up_client = NULL;
-        }
-#endif
 
         g_clear_object (&logout_dialog->priv->system);
 

--- a/meson.build
+++ b/meson.build
@@ -43,12 +43,6 @@ xau         = dependency('xau')
 xcomposite  = dependency('xcomposite')
 gl          = dependency('gl')
 
-# We only support old upower
-# https://bugzilla.gnome.org/show_bug.cgi?id=710383
-upower_old  = dependency('upower-glib', version: '<0.99.0', required: false)
-conf.set('HAVE_OLD_UPOWER', upower_old.found())
-
-
 if get_option('with-gconf')
   gconf     = dependency('gconf-2.0')
 else
@@ -196,7 +190,6 @@ message('\n'.join([
 '        Backtrace support:        @0@'.format(backtrace.found()),
 '        XRender support:          @0@'.format(xrender.found()),
 '        XTest support:            @0@'.format(xtest.found()),
-'        Legacy UPower backend:    @0@'.format(upower_old.found()),
 '        Build documentation:      @0@'.format(docbook_enabled),
 '',
 ]))


### PR DESCRIPTION
Removes dependency on old upower. Tested on Slackware-14.2 with ConsoleKit2 1.0.0 and UPower 0.99.7.