### PR TITLE
[4.6] csm-system: Check for logind and fall back to consolekit

### DIFF
--- a/cinnamon-session/csm-system.c
+++ b/cinnamon-session/csm-system.c
@@ -170,22 +170,20 @@ csm_get_system (void)
         static CsmSystem *system = NULL;
 
         if (system == NULL) {
-                GSettings *session_settings = g_settings_new ("org.cinnamon.desktop.session");
-                if (g_settings_get_boolean (session_settings, "session-manager-uses-logind")) {
-                  // Use logind
-                  system = CSM_SYSTEM (csm_systemd_new ());
-                  if (system != NULL) {
+                // Use logind
+                system = CSM_SYSTEM (csm_systemd_new ());
+
+                if (system != NULL) {
                         g_debug ("Using systemd for session tracking");
-                  }
                 }
                 else {
-                  // Use consolekit
-                  system = CSM_SYSTEM (csm_consolekit_new ());
-                  if (system != NULL) {
-                        g_debug ("Using ConsoleKit for session tracking");
-                  }
+                        // Use consolekit
+                        system = CSM_SYSTEM (csm_consolekit_new ());
+
+                        if (system != NULL) {
+                                g_debug ("Using ConsoleKit for session tracking");
+                        }
                 }
-                g_object_unref (session_settings);
         }
 
         return g_object_ref (system);

--- a/cinnamon-session/csm-systemd.c
+++ b/cinnamon-session/csm-systemd.c
@@ -739,7 +739,7 @@ csm_systemd_new (void)
         CsmSystemd *manager;
 
         /* logind is not running ? */
-        if (access("/run/systemd/seats/", F_OK) < 0)
+        if (access("/run/systemd/system/", F_OK) < 0) // sd_booted ()
                 return NULL;
 
         manager = g_object_new (CSM_TYPE_SYSTEMD, NULL);
@@ -747,7 +747,7 @@ csm_systemd_new (void)
         return manager;
 }
 
-#else
+#else /* HAVE_LOGIND */
 
 CsmSystemd *
 csm_systemd_new (void)
@@ -755,4 +755,4 @@ csm_systemd_new (void)
         return NULL;
 }
 
-#endif
+#endif /* HAVE_LOGIND */


### PR DESCRIPTION
Instead of using a gsettings key to determine which to use.


related:
https://github.com/linuxmint/cinnamon-settings-daemon/pull/273
https://github.com/linuxmint/cinnamon-desktop/pull/138
