### PR TITLE
Clean-up remaining dbus-glib references after removal in #125

### DIFF
--- a/cinnamon-session/csm-util.c
+++ b/cinnamon-session/csm-util.c
@@ -32,8 +32,6 @@
 #include <glib/gstdio.h>
 #include <gtk/gtk.h>
 
-#include <dbus/dbus-glib.h>
-
 #include "csm-util.h"
 
 static gchar *_saved_session_dir = NULL;

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,6 @@ Build-Depends:
  gnome-pkg-tools (>= 0.13),
  intltool (>= 0.40.6),
  libcanberra-dev,
- libdbus-glib-1-dev (>= 0.88),
  libgl1-mesa-dev,
  libglib2.0-dev (>= 2.37.3),
  libgtk-3-dev (>= 3.0.0),


### PR DESCRIPTION
The dbus-glib dependency was dropped in #125. However, it is still included in `csm-util.c`, which was previously ported.

This doesn't cause any problem for me, but another Gentoo user was reporting a compile error when testing out a new ebuild package.

Down stream bug:
https://bugs.gentoo.org/704532