### PR TITLE
Fix elogind support

### DIFF
--- a/cinnamon-session/csm-systemd.c
+++ b/cinnamon-session/csm-systemd.c
@@ -23,7 +23,7 @@
 #include "config.h"
 #include "csm-systemd.h"
 
-#ifdef HAVE_LOGIND
+#if defined(HAVE_LOGIND) || defined(HAVE_ELOGIND)
 
 #include <errno.h>
 #include <string.h>

--- a/cinnamon-session/meson.build
+++ b/cinnamon-session/meson.build
@@ -74,7 +74,7 @@ executable('cinnamon-session',
     xext,
     xrender,
     xtest,
-    # elogind,
+    elogind,
   ],
   link_with: [
     libegg,


### PR DESCRIPTION
Backporting a patch from Gentoo to (re)enable support for elogind. It seems like it was committed this way a while back with meson port #108.

Please, let me know if there are any concerns around this.