### PR TITLE
(experiment) Don't wait for the logout sound to finish before logout

### DIFF
--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -2937,10 +2937,6 @@ maybe_play_logout_sound (CsmManager *manager)
         }
         g_free(sound);
         g_object_unref (settings);    
-
-        while (manager->priv->logout_sound_is_playing) {
-            sleep(1);
-        }
 }
 
 static void


### PR DESCRIPTION
The sound should be able to play while the desktop is logging out. There
is no need for a long pause if the sound can play.
----------------------------------------------------------
I have no idea if this has been checked or tested before, but my hope, from what I've at least seen with DDE (from what I remember) is that until the audio service shutdowns (which I belive is after the desktop shuts down) the sound can continue playing.