### PR TITLE
autostart-app: don't try to add child watch to dbus activated

### DIFF
--- a/cinnamon-session/csm-autostart-app.c
+++ b/cinnamon-session/csm-autostart-app.c
@@ -1056,10 +1056,12 @@ autostart_app_start_spawn (CsmAutostartApp *app,
         g_signal_handler_disconnect (ctx, handler);
 
         if (success) {
-                g_debug ("CsmAutostartApp: started pid:%d", app->priv->pid);
-                app->priv->child_watch_id = g_child_watch_add (app->priv->pid,
-                                                               (GChildWatchFunc)app_exited,
-                                                               app);
+                if (app->priv->pid > 0) {
+                        g_debug ("CsmAutostartApp: started pid:%d", app->priv->pid);
+                        app->priv->child_watch_id = g_child_watch_add (app->priv->pid,
+                                                                       (GChildWatchFunc)app_exited,
+                                                                       app);
+                }
         } else {
                 g_set_error (error,
                              CSM_APP_ERROR,


### PR DESCRIPTION
 services.

Based on https://github.com/GNOME/gnome-session/commit/dc0993025c27affde6ccb7eb51dfc14b4e9f3b08

If a service is dbus activated, then gnome-session isn't starting it
directly and it makes no sense to try to create a child watch on it.

This commit ensures, child watches are only set up on apps that are
started directly by gnome-session, which avoids generating a critical
message in the log for each dbus activated app.

https://gitlab.gnome.org/GNOME/gnome-session/issues/14