### PR TITLE
Fix dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
 Build-Depends:
  debhelper (>= 11.1~),
+ dh-sequence-python3,
  gnome-pkg-tools (>= 0.13),
  intltool (>= 0.40.6),
  libcanberra-dev,
@@ -34,8 +35,15 @@ Depends:
  cinnamon-desktop-data (>= 6.0),
  cinnamon-session-common (= ${source:Version}),
  default-dbus-session-bus | dbus-session-bus,
+ gir1.2-glib-2.0,
+ gir1.2-gtk-3.0,
+ gir1.2-xapp-1.0,
+ python3-gi,
+ python3-setproctitle,
  upower (>= 0.9.0),
+ ${gir:Depends},
  ${misc:Depends},
+ ${python3:Depends},
  ${shlibs:Depends},
 Recommends: cinnamon-l10n
 Breaks: cinnamon-session-common (<< 2.2.2-5~)

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  gnome-pkg-tools (>= 0.13),
  intltool (>= 0.40.6),
  libcanberra-dev,
- libcinnamon-desktop-dev,
+ libcinnamon-desktop-dev (>= 6.0),
  libgl1-mesa-dev,
  libglib2.0-dev (>= 2.37.3),
  libgtk-3-dev (>= 3.0.0),
@@ -31,7 +31,7 @@ Standards-Version: 3.9.6
 Package: cinnamon-session
 Architecture: any
 Depends:
- cinnamon-desktop-data (>= 3.6),
+ cinnamon-desktop-data (>= 6.0),
  cinnamon-session-common (= ${source:Version}),
  default-dbus-session-bus | dbus-session-bus,
  upower (>= 0.9.0),

--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,7 @@ xapp        = dependency('xapp', version: '>=1.0.4')
 xau         = dependency('xau')
 xcomposite  = dependency('xcomposite')
 gl          = dependency('gl')
-cinnamon_desktop = dependency('cinnamon-desktop', version: '>=5.8.0')
+cinnamon_desktop = dependency('cinnamon-desktop', version: '>=6.0.0')
 
 gio_unix    = dependency('gio-unix-2.0',      required: false)
 libelogind  = dependency('libelogind',        required: false)


### PR DESCRIPTION
-  meson: increase cinnamon-desktop dep. to 6.0
cinnamon-desktop 6.0 is required or fails to build (for missed
gnome-idle-monitor file)
- debian: add strict build-dep and dep to cinnamon-desktop 6.0
- debian: add missed depends for new cinnamon-session-quit.py