### PR TITLE
cinnamon-session: make sure wayland sessions get a login shell

### DIFF
--- a/cinnamon-session/cinnamon-session.in
+++ b/cinnamon-session/cinnamon-session.in
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ "x$XDG_SESSION_TYPE" = "xwayland" ] &&
+   [ "x$XDG_SESSION_CLASS" != "xgreeter" ] &&
+   [  -n "$SHELL" ] &&
+   grep -q "$SHELL" /etc/shells &&
+   ! (echo "$SHELL" | grep -q "false") &&
+   ! (echo "$SHELL" | grep -q "nologin"); then
+  if [ "$1" != '-l' ]; then
+    exec bash -c "exec -l '$SHELL' -c '$0 -l $*'"
+  else
+    shift
+  fi
+fi
+
+exec @libexecdir@/cinnamon-session-binary "$@"

--- a/cinnamon-session/meson.build
+++ b/cinnamon-session/meson.build
@@ -53,7 +53,7 @@ cinnamon_session_sources = [
   gdbus_sources,
 ]
 
-executable('cinnamon-session',
+executable('cinnamon-session-binary',
   cinnamon_session_sources,
   dependencies: [
     cinnamon_desktop,
@@ -75,6 +75,18 @@ executable('cinnamon-session',
   ],
   include_directories: [ rootInclude ],
   install: true,
+  install_dir: get_option('libexecdir'),
+)
+
+script_conf = configuration_data()
+script_conf.set('libexecdir', get_option('prefix') / get_option('libexecdir'))
+
+configure_file(
+  input: 'cinnamon-session.in',
+  output: 'cinnamon-session',
+  install: true,
+  install_dir: get_option('bindir'),
+  configuration: script_conf
 )
 
 units = [


### PR DESCRIPTION
Users expect their shell profiles to get sourced at startup, which doesn't happen with wayland sessions.

This commit brings back that feature, by making the cinnamon-session wrapper script run a login shell.

ref: https://gitlab.gnome.org/GNOME/gnome-session/-/commit/7e307f8ddb91db5d4051c4c792519a660ba67f35

---

Edit: See the comments in https://github.com/NixOS/nixpkgs/pull/276060 for background I guess, in the original issue we want to append some paths to `GI_TYPELIB_PATH` in `/etc/profiles` but when checking `imports.gi.GIRepository.Repository.get_search_path()` in Melange we found that this does not work, the issue only seems to happen with the combination of GDM + Cinnamon Wayland so far ([this GDM issue](https://gitlab.gnome.org/GNOME/gdm/-/issues/770)).