### PR TITLE
Remove orphaned systemd include

### DIFF
--- a/cinnamon-session/main.c
+++ b/cinnamon-session/main.c
@@ -40,7 +40,6 @@
 #include "csm-session-fill.h"
 #include "csm-store.h"
 #include "csm-system.h"
-#include <systemd/sd-journal.h>
 
 #define CSM_DBUS_NAME "org.gnome.SessionManager"
 


### PR DESCRIPTION
Remove a systemd include added by c91baef72d08fbcbcbbd1ecad840c02cc9020630 and orphaned by 4d134d3910b8c7da5aa39b4b85dd7947464e445f