### PR TITLE
csm-manager.c: Add functionality to restart the cinnamon-launcher on-demand

### DIFF
--- a/cinnamon-session/csm-consolekit.c
+++ b/cinnamon-session/csm-consolekit.c
@@ -859,6 +859,12 @@ csm_consolekit_is_last_session_for_user (CsmSystem *system)
         return FALSE;
 }
 
+static gchar *
+csm_consolekit_get_login_session_id (CsmSystem *system)
+{
+        return NULL;
+}
+
 static void
 csm_consolekit_system_init (CsmSystemInterface *iface)
 {
@@ -876,6 +882,7 @@ csm_consolekit_system_init (CsmSystemInterface *iface)
         iface->add_inhibitor = csm_consolekit_add_inhibitor;
         iface->remove_inhibitor = csm_consolekit_remove_inhibitor;
         iface->is_last_session_for_user = csm_consolekit_is_last_session_for_user;
+        iface->get_login_session_id = csm_consolekit_get_login_session_id;
 }
 
 CsmConsolekit *

--- a/cinnamon-session/csm-manager.h
+++ b/cinnamon-session/csm-manager.h
@@ -143,6 +143,8 @@ void                _csm_manager_set_active_session            (CsmManager     *
                                                                 const char     *session_name,
                                                                 gboolean        is_fallback);
 
+void                _csm_manager_export_login_session_id       (CsmManager     *manager);
+
 gboolean            csm_manager_set_phase                      (CsmManager     *manager,
                                                                 CsmManagerPhase phase);
 

--- a/cinnamon-session/csm-session-fill.c
+++ b/cinnamon-session/csm-session-fill.c
@@ -496,6 +496,7 @@ csm_session_fill (CsmManager  *manager,
         }
 
         _csm_manager_set_active_session (manager, actual_session, is_fallback);
+        _csm_manager_export_login_session_id (manager);
 
         g_free (actual_session);
 

--- a/cinnamon-session/csm-system.c
+++ b/cinnamon-session/csm-system.c
@@ -164,6 +164,12 @@ csm_system_is_last_session_for_user (CsmSystem *system)
         return CSM_SYSTEM_GET_IFACE (system)->is_last_session_for_user (system);
 }
 
+gchar *
+csm_system_get_login_session_id (CsmSystem    *system)
+{
+        return CSM_SYSTEM_GET_IFACE (system)->get_login_session_id (system);
+}
+
 CsmSystem *
 csm_get_system (void)
 {

--- a/cinnamon-session/csm-system.h
+++ b/cinnamon-session/csm-system.h
@@ -70,6 +70,7 @@ struct _CsmSystemInterface
         void     (* remove_inhibitor) (CsmSystem        *system,
                                        const gchar      *id);
         gboolean (* is_last_session_for_user) (CsmSystem *system);
+        gchar *  (* get_login_session_id) (CsmSystem *system);
 };
 
 enum _CsmSystemError {
@@ -119,7 +120,7 @@ void       csm_system_add_inhibitor    (CsmSystem        *system,
 
 void       csm_system_remove_inhibitor (CsmSystem        *system,
                                         const gchar      *id);
-
+gchar     *csm_system_get_login_session_id (CsmSystem    *system);
 G_END_DECLS
 
 #endif /* __CSM_SYSTEM_H__ */

--- a/cinnamon-session/csm-systemd.c
+++ b/cinnamon-session/csm-systemd.c
@@ -718,6 +718,26 @@ csm_systemd_is_last_session_for_user (CsmSystem *system)
         return is_last_session;
 }
 
+static gchar *
+csm_systemd_get_login_session_id (CsmSystem *system)
+{
+        CsmSystemd *manager = CSM_SYSTEMD (system);
+
+        gchar *pid_session;
+        gint ret;
+
+        ret = sd_pid_get_session (getpid (), &pid_session);
+
+        if (ret < 0) {
+            g_printerr ("can't get login session id for cinnamon-session. errno: %d\n", -ret);
+            return NULL;
+        }
+
+        g_debug ("Login session ID is: %s\n", pid_session);
+
+        return pid_session;
+}
+
 static void
 csm_systemd_system_init (CsmSystemInterface *iface)
 {
@@ -737,6 +757,7 @@ csm_systemd_system_init (CsmSystemInterface *iface)
         iface->add_inhibitor = csm_systemd_add_inhibitor;
         iface->remove_inhibitor = csm_systemd_remove_inhibitor;
         iface->is_last_session_for_user = csm_systemd_is_last_session_for_user;
+        iface->get_login_session_id = csm_systemd_get_login_session_id;
 }
 
 CsmSystemd *

--- a/cinnamon-session/org.gnome.SessionManager.xml
+++ b/cinnamon-session/org.gnome.SessionManager.xml
@@ -431,5 +431,20 @@
       </doc:doc>
     </property>
 
+    <property name="SessionId" type="s" access="read">
+      <doc:doc>
+        <doc:description>
+          <doc:para>The login session ID of cinnamon-session.</doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <method name="RestartCinnamonLauncher">
+      <doc:doc>
+        <doc:description>
+          <doc:para>Launches cinnamon-launcher for current session.</doc:para>
+        </doc:description>
+      </doc:doc>
+    </method>
   </interface>
 </node>


### PR DESCRIPTION
This allows cinnamon to be restarted under the correct login session to prevent blocking of polkit authentication.