### PR TITLE
Add graphical session support

### DIFF
--- a/cinnamon-session/csm-manager.c
+++ b/cinnamon-session/csm-manager.c
@@ -873,6 +873,8 @@ do_phase_end_session (CsmManager *manager)
 
         close_end_session_dialog (manager);
 
+        csm_util_stop_systemd_unit ("cinnamon-session.target", "replace", NULL);
+
         if (manager->priv->logout_mode == CSM_MANAGER_LOGOUT_MODE_FORCE) {
                 data.flags |= CSM_CLIENT_END_SESSION_FLAG_FORCEFUL;
         }
@@ -1523,6 +1525,7 @@ start_phase (CsmManager *manager)
                 csm_xsmp_server_start_accepting_new_clients (manager->priv->xsmp_server);
                 csm_exported_manager_emit_session_running (manager->priv->skeleton);
                 update_idle (manager);
+                csm_util_start_systemd_unit ("cinnamon-session.target", "replace", NULL);
                 break;
         case CSM_MANAGER_PHASE_QUERY_END_SESSION:
                 csm_xsmp_server_stop_accepting_new_clients (manager->priv->xsmp_server);

--- a/cinnamon-session/csm-util.c
+++ b/cinnamon-session/csm-util.c
@@ -763,6 +763,72 @@ csm_util_update_user_environment (const char  *variable,
         return environment_updated;
 }
 
+gboolean
+csm_util_start_systemd_unit (const char  *unit,
+                             const char  *mode,
+                             GError     **error)
+{
+        g_autoptr(GDBusConnection) connection = NULL;
+        g_autoptr(GVariant)        reply = NULL;
+        GError          *bus_error = NULL;
+
+        connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, error);
+
+        if (connection == NULL)
+                return FALSE;
+
+        reply = g_dbus_connection_call_sync (connection,
+                                             "org.freedesktop.systemd1",
+                                             "/org/freedesktop/systemd1",
+                                             "org.freedesktop.systemd1.Manager",
+                                             "StartUnit",
+                                             g_variant_new ("(ss)",
+                                                            unit, mode),
+                                             NULL,
+                                             G_DBUS_CALL_FLAGS_NONE,
+                                             -1, NULL, &bus_error);
+
+        if (bus_error != NULL) {
+                g_propagate_error (error, bus_error);
+                return FALSE;
+        }
+
+        return TRUE;
+}
+
+gboolean
+csm_util_stop_systemd_unit (const char  *unit,
+                             const char  *mode,
+                             GError     **error)
+{
+        g_autoptr(GDBusConnection) connection = NULL;
+        g_autoptr(GVariant)        reply = NULL;
+        GError          *bus_error = NULL;
+
+        connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, error);
+
+        if (connection == NULL)
+                return FALSE;
+
+        reply = g_dbus_connection_call_sync (connection,
+                                             "org.freedesktop.systemd1",
+                                             "/org/freedesktop/systemd1",
+                                             "org.freedesktop.systemd1.Manager",
+                                             "StopUnit",
+                                             g_variant_new ("(ss)",
+                                                            unit, mode),
+                                             NULL,
+                                             G_DBUS_CALL_FLAGS_NONE,
+                                             -1, NULL, &bus_error);
+
+        if (bus_error != NULL) {
+                g_propagate_error (error, bus_error);
+                return FALSE;
+        }
+
+        return TRUE;
+}
+
 void
 csm_util_setenv (const char *variable,
                  const char *value)

--- a/cinnamon-session/csm-util.h
+++ b/cinnamon-session/csm-util.h
@@ -58,6 +58,13 @@ gboolean    csm_util_export_user_environment        (GError     **error);
 void        csm_util_setenv                         (const char *variable,
                                                      const char *value);
 
+gboolean    csm_util_start_systemd_unit             (const char  *unit,
+                                                     const char  *mode,
+                                                     GError     **error);
+gboolean    csm_util_stop_systemd_unit              (const char  *unit,
+                                                     const char  *mode,
+                                                     GError     **error);
+
 // main.c, exit mainloop
 void        csm_quit                                (void);
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -20,3 +20,6 @@ install_data(
 
 # Re-compile gsettings
 meson.add_install_script('meson_install_schemas.py')
+
+subdir('systemd/user')
+

--- a/data/systemd/user/cinnamon-session.target
+++ b/data/systemd/user/cinnamon-session.target
@@ -1,0 +1,14 @@
+[Unit]
+Description=Cinnamon graphical session
+Documentation=man:systemd.special(7)
+
+Wants=graphical-session.target
+Before=graphical-session.target
+
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target
+
+PropagatesStopTo=graphical-session.target
+PropagatesStopTo=graphical-session-pre.target
+
+CollectMode=inactive-or-failed

--- a/data/systemd/user/meson.build
+++ b/data/systemd/user/meson.build
@@ -1,0 +1,8 @@
+if enable_systemd
+install_data(
+  [
+    'cinnamon-session.target',
+  ],
+  install_dir: systemduserunitdir,
+)
+endif

--- a/debian/cinnamon-session.install
+++ b/debian/cinnamon-session.install
@@ -1,5 +1,6 @@
 usr/bin/cinnamon-session*
 usr/lib/*/cinnamon-session*
+usr/lib/systemd/user/cinnamon-session.target
 usr/share/cinnamon-session
 usr/share/glib-2.0/schemas/org.cinnamon.SessionManager.gschema.xml
 usr/share/man/*/cinnamon-session*

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,23 @@ else
 endif
 conf.set('HAVE_LOGIND', logind.found())
 
+systemd_opt = get_option('systemd')
+systemd_dep = dependency('libsystemd', required: systemd_opt.enabled())
+if systemd_dep.found()
+  systemduserunitdir = systemd_dep.get_variable(
+    pkgconfig: 'systemduserunitdir',
+    default_value: join_paths(get_option('prefix'), 'lib', 'systemd', 'user')
+  )
+  enable_systemd = true
+else
+  enable_systemd = systemd_dep.found() and not systemd_opt.disabled()
+  systemduserunitdir = join_paths(get_option('prefix'), 'lib', 'systemd', 'user')
+endif
+
+message('Systemd integration: ' + (enable_systemd ? 'enabled' : 'disabled'))
+message('Systemd user unit dir: ' + systemduserunitdir)
+
+
 if gio_unix.found() and libelogind.found()
   elogind = declare_dependency(dependencies: [ gio_unix, libelogind ])
 else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,5 @@
 option('frequent_warnings',  type: 'boolean', value: false)
 option('ipv6',               type: 'boolean', value: true)
 option('xtrans',             type: 'boolean', value: true)
+option('systemd',            type: 'feature', value: 'auto')
+


### PR DESCRIPTION
```
session: Add graphical-session.target support

Activate the cross-desktop graphical-session.target and
graphical-session-pre.target when the Cinnamon session starts, so
that systemd-managed services which declare WantedBy= or PartOf=
against those targets are started and stopped in sync with the
session.

graphical-session.target and graphical-session-pre.target have
RefuseManualStart=yes so they cannot be started directly.  Instead
a new cinnamon-session.target is introduced which declares
Wants=graphical-session.target and Wants=graphical-session-pre.target;
systemd then pulls the cross-desktop targets up as dependencies when
cinnamon-session.target is started.

PropagatesStopTo= on cinnamon-session.target ensures that stopping it
on logout propagates to graphical-session.target and
graphical-session-pre.target, which in turn stops any PartOf= services.

The stop is issued at the beginning of CSM_MANAGER_PHASE_END_SESSION,
immediately after the end-session dialog closes, so that systemd-managed
services begin shutting down in parallel with the XSMP end-session
sequence rather than waiting until after it.

Two new helpers are added to csm-util.c:

  csm_util_start_systemd_unit(unit, mode, error)
  csm_util_stop_systemd_unit(unit, mode, error)

Both use g_autoptr and synchronous D-Bus calls via the session bus.

Systemd integration is controlled by a new 'systemd' feature option
(default: auto) and is skipped entirely when libsystemd is not present.
```