### PR TITLE
Update cinnamon-session.target to manage waybar.service

### DIFF
--- a/data/systemd/user/cinnamon-session.target
+++ b/data/systemd/user/cinnamon-session.target
@@ -11,4 +11,10 @@ After=graphical-session-pre.target
 PropagatesStopTo=graphical-session.target
 PropagatesStopTo=graphical-session-pre.target
 
+# waybar.service declares WantedBy=graphical-session.target with no
+# compositor scoping, so it gets pulled in under any session that wants
+# graphical-session.target - including Cinnamon, which it doesn't support.
+Conflicts=waybar.service
+Before=waybar.service
+
 CollectMode=inactive-or-failed


### PR DESCRIPTION
Add conflict and ordering for waybar.service in cinnamon-session.target

The waybar maintainer has no interest in playing nicely, see

https://github.com/Alexays/Waybar/pull/5135