### PR TITLE
session: Add a drop-in for the application scopes cinnamon creates

### DIFF
--- a/data/systemd/user/app-override.scope.conf
+++ b/data/systemd/user/app-override.scope.conf
@@ -1,0 +1,6 @@
+[Unit]
+CollectMode=inactive-or-failed
+PartOf=graphical-session.target
+
+[Scope]
+TimeoutStopSec=5s

--- a/data/systemd/user/meson.build
+++ b/data/systemd/user/meson.build
@@ -5,4 +5,12 @@ install_data(
   ],
   install_dir: systemduserunitdir,
 )
+
+# Applies to the transient scopes cinnamon creates for launched applications
+install_data(
+  [
+    'app-override.scope.conf',
+  ],
+  install_dir: systemduserunitdir / 'app-cinnamon-.scope.d',
+)
 endif

--- a/debian/cinnamon-session.install
+++ b/debian/cinnamon-session.install
@@ -1,5 +1,6 @@
 usr/bin/cinnamon-session*
 usr/lib/*/cinnamon-session*
+usr/lib/systemd/user/app-cinnamon-.scope.d/app-override.scope.conf
 usr/lib/systemd/user/cinnamon-session.target
 usr/share/cinnamon-session
 usr/share/glib-2.0/schemas/org.cinnamon.SessionManager.gschema.xml


### PR DESCRIPTION
With linuxmint/cinnamon-desktop#275, cinnamon puts every application it launches into a transient `app-cinnamon-*.scope`. Those scopes are created with nothing but a PID list, so systemd knows nothing about their lifetime: at logout they are torn down abruptly when the user instance goes away, and if the user has lingering enabled they are not torn down at all.

This ships the same drop-in gnome-session ships for its own scopes (`data/app-override.scope.conf`, installed into `app-gnome-.scope.d/`):

* `PartOf=graphical-session.target` ties the applications to the session, so they are stopped when it ends instead of being killed when the user instance goes down.
* `TimeoutStopSec=5s` gives them a moment to exit cleanly first.
* `CollectMode=inactive-or-failed` keeps failed units from piling up.

This relies on `graphical-session.target` being activated by the session, which has been the case since e01c8c3 (#204).

### Testing

Mint 23, Cinnamon 6.7.4 with the cinnamon-desktop fix applied — the drop-in is picked up by the scopes as they are created:

```
$ systemctl --user show app-cinnamon-debian-xterm-18470.scope \
      -p PartOf -p CollectMode -p TimeoutStopUSec -p Slice
PartOf=graphical-session.target
CollectMode=inactive-or-failed
TimeoutStopUSec=5s
Slice=app.slice
```

### One caveat worth stating

`graphical-session.target` belongs to the systemd user instance, which is per user, not per session. If the same user has two graphical sessions running at once, logging out of one stops the application scopes of the other as well. Before application scopes existed the applications lived in their own `session-N.scope` and were unaffected. This is the same trade-off GNOME makes, and the multi-session case is rare, but it is a real behaviour change.